### PR TITLE
Add version info for software library and on-disk structures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,3 +45,31 @@ before_script:
     - sudo chmod a+rw /dev/loop0
     - dd if=/dev/zero bs=512 count=2048 of=disk
     - losetup /dev/loop0 disk
+
+deploy:
+    # Let before_deploy take over
+    provider: script
+    script: 'true'
+    on:
+        branch: master
+
+before_deploy:
+    - cd $TRAVIS_BUILD_DIR
+    # Update tag for version defined in lfs.h
+    - LFS_VERSION=$(grep -ox '#define LFS_VERSION .*' lfs.h | cut -d ' ' -f3)
+    - LFS_VERSION_MAJOR=$((0xffff & ($LFS_VERSION >> 16)))
+    - LFS_VERSION_MINOR=$((0xffff & ($LFS_VERSION >>  0)))
+    - LFS_VERSION="v$LFS_VERSION_MAJOR.$LFS_VERSION_MINOR"
+    - |
+      curl -u $GEKY_BOT -X POST \
+        https://api.github.com/repos/$TRAVIS_REPO_SLUG/git/refs \
+        -d @- <<< "{
+          \"ref\": \"refs/tags/$LFS_VERSION\",
+          \"sha\": \"$TRAVIS_COMMIT\"
+        }"
+    - |
+      curl -f -u $GEKY_BOT -X PATCH \
+        https://api.github.com/repos/$TRAVIS_REPO_SLUG/git/refs/tags/$LFS_VERSION \
+        -d @- <<< "{
+          \"sha\": \"$TRAVIS_COMMIT\"
+        }"

--- a/lfs.c
+++ b/lfs.c
@@ -2067,7 +2067,7 @@ int lfs_format(lfs_t *lfs, const struct lfs_config *cfg) {
         .d.type = LFS_TYPE_SUPERBLOCK,
         .d.elen = sizeof(superblock.d) - sizeof(superblock.d.magic) - 4,
         .d.nlen = sizeof(superblock.d.magic),
-        .d.version = 0x00010001,
+        .d.version = LFS_DISK_VERSION,
         .d.magic = {"littlefs"},
         .d.block_size  = lfs->cfg->block_size,
         .d.block_count = lfs->cfg->block_count,
@@ -2140,10 +2140,11 @@ int lfs_mount(lfs_t *lfs, const struct lfs_config *cfg) {
         return LFS_ERR_CORRUPT;
     }
 
-    if (superblock.d.version > (0x00010001 | 0x0000ffff)) {
-        LFS_ERROR("Invalid version %d.%d",
-                0xffff & (superblock.d.version >> 16),
-                0xffff & (superblock.d.version >> 0));
+    uint16_t major_version = (0xffff & (superblock.d.version >> 16));
+    uint16_t minor_version = (0xffff & (superblock.d.version >>  0));
+    if ((major_version != LFS_DISK_VERSION_MAJOR ||
+         minor_version > LFS_DISK_VERSION_MINOR)) {
+        LFS_ERROR("Invalid version %d.%d", major_version, minor_version);
         return LFS_ERR_INVAL;
     }
 

--- a/lfs.h
+++ b/lfs.h
@@ -22,6 +22,23 @@
 #include <stdbool.h>
 
 
+/// Version info ///
+
+// Software library version
+// Major (top-nibble), incremented on backwards incompatible changes
+// Minor (bottom-nibble), incremented on feature additions
+#define LFS_VERSION 0x00010002
+#define LFS_VERSION_MAJOR (0xffff & (LFS_VERSION >> 16))
+#define LFS_VERSION_MINOR (0xffff & (LFS_VERSION >>  0))
+
+// Version of On-disk data structures
+// Major (top-nibble), incremented on backwards incompatible changes
+// Minor (bottom-nibble), incremented on feature additions
+#define LFS_DISK_VERSION 0x00010001
+#define LFS_DISK_VERSION_MAJOR (0xffff & (LFS_DISK_VERSION >> 16))
+#define LFS_DISK_VERSION_MINOR (0xffff & (LFS_DISK_VERSION >>  0))
+
+
 /// Definitions ///
 
 // Type definitions


### PR DESCRIPTION
Here's a proposal for versioning littlefs.

In this patch, littlefs provides two version numbers at compile time, with major and minor parts, in the form of 6 macros.

``` c
LFS_VERSION        // Library version, uint32_t encoded
LFS_VERSION_MAJOR  // Major - Backwards incompatible changes
LFS_VERSION_MINOR  // Minor - Feature additions

LFS_DISK_VERSION        // On-disk version, uint32_t encoded
LFS_DISK_VERSION_MAJOR  // Major - Backwards incompatible changes
LFS_DISK_VERSION_MINOR  // Minor - Feature additions
```

Note that littlefs will error if it finds a major version number that is different, or a minor version number that has regressed.

related https://github.com/geky/littlefs/issues/10